### PR TITLE
feat(default): add dilna deployment

### DIFF
--- a/kubernetes/apps/default/dilna/app/externalsecret.yaml
+++ b/kubernetes/apps/default/dilna/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dilna
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: dilna-secret
+    template:
+      engineVersion: v2
+      data:
+        SSH_PRIVATE_KEY: "{{ .SSH_PRIVATE_KEY }}"
+  dataFrom:
+    - extract:
+        key: dilna

--- a/kubernetes/apps/default/dilna/app/helmrelease.yaml
+++ b/kubernetes/apps/default/dilna/app/helmrelease.yaml
@@ -33,10 +33,11 @@ spec:
             env:
               TZ: Europe/Madrid
             probes:
-              liveness:
+              liveness: &probes
                 enabled: true
-              readiness:
-                enabled: true
+                type: HTTP
+                path: /api/health
+              readiness: *probes
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false

--- a/kubernetes/apps/default/dilna/app/helmrelease.yaml
+++ b/kubernetes/apps/default/dilna/app/helmrelease.yaml
@@ -1,0 +1,84 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app dilna
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: dilna
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      dilna:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/mrmarble/dilna
+              tag: main
+              pullPolicy: Always
+            env:
+              TZ: Europe/Madrid
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: dilna-pull-secret
+    service:
+      app:
+        controller: dilna
+        ports:
+          http:
+            primary: true
+            port: 3001
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.atsbhome.xyz"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      data:
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        storageClass: longhorn
+        globalMounts:
+          - path: /data
+      ssh:
+        type: secret
+        name: dilna-secret
+        defaultMode: 0400
+        items:
+          - key: SSH_PRIVATE_KEY
+            path: id_rsa
+        globalMounts:
+          - path: /root/.ssh/id_rsa
+            subPath: id_rsa
+            readOnly: true

--- a/kubernetes/apps/default/dilna/app/kustomization.yaml
+++ b/kubernetes/apps/default/dilna/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./pullsecret.yaml
+  - ./helmrelease.yaml
+  - ../../../../templates/gatus/guarded

--- a/kubernetes/apps/default/dilna/app/pullsecret.yaml
+++ b/kubernetes/apps/default/dilna/app/pullsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dilna-pull-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: dilna-pull-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {"auths":{"ghcr.io":{"username":"{{ .GITHUB_USERNAME }}","auth":"{{ printf "%s:%s" .GITHUB_USERNAME .GITHUB_PAT | b64enc }}"}}}
+  dataFrom:
+    - extract:
+        key: dilna

--- a/kubernetes/apps/default/dilna/ks.yaml
+++ b/kubernetes/apps/default/dilna/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: =https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dilna
+spec:
+  components:
+    - ../../../../components/oci-repository
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/default/dilna/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -4,5 +4,6 @@ namespace: default
 resources:
   - ./namespace.yaml
   - ./archi/ks.yaml
+  - ./dilna/ks.yaml
   - ./immich/ks.yaml
   - ./psitransfer/ks.yaml


### PR DESCRIPTION
Deploy ghcr.io/mrmarble/dilna:main via the shared app-template chart, pulling a private ghcr image with an external-secrets backed dockerconfigjson pull secret, and mounting an SSH key for git operations plus a 5Gi longhorn volume for repo persistence.