### PR TITLE
feat(dilna): increase memory limit to 1Gi

### DIFF
--- a/kubernetes/apps/default/dilna/app/helmrelease.yaml
+++ b/kubernetes/apps/default/dilna/app/helmrelease.yaml
@@ -68,7 +68,7 @@ spec:
                 cpu: 10m
                 memory: 128Mi
               limits:
-                memory: 512Mi
+                memory: 1Gi
     defaultPodOptions:
       securityContext:
         # Claude Code's bypassPermissions mode (dilna's ADR-0003/0010)


### PR DESCRIPTION
## Summary
- Bump dilna's container memory limit from 512Mi to 1Gi — the pod was hitting the previous limit regularly.

## Test plan
- [ ] Flux reconciles the HelmRelease and the pod comes up healthy with the new limit